### PR TITLE
feat: add CommitsOnBranchSimple

### DIFF
--- a/commits_on_branch_simple.go
+++ b/commits_on_branch_simple.go
@@ -1,0 +1,42 @@
+package git
+
+import (
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+type SimpleCommit struct {
+	Hash    [20]byte
+	Message string
+}
+
+// CommitsOnBranchSimple iterates through all references and returns simpleCommits on given branch. \n
+// Important to note is that this will provide all commits from anything the branch is connected to.
+func (g *Git) CommitsOnBranchSimple(
+	branchCommit plumbing.Hash,
+) ([]SimpleCommit, error) {
+	var branchCommits []SimpleCommit
+
+	branchIter, err := g.repo.Log(&git.LogOptions{
+		From: branchCommit,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	branchIterErr := branchIter.ForEach(func(commit *object.Commit) error {
+		branchCommits = append(branchCommits, SimpleCommit{
+			Hash:    commit.Hash,
+			Message: commit.Message,
+		})
+		return nil
+	})
+
+	if branchIterErr != nil {
+		g.DebugLogger.Printf("Stopped getting commits on branch: %v", branchIterErr)
+	}
+
+	return branchCommits, nil
+}

--- a/commits_on_branch_simple_test.go
+++ b/commits_on_branch_simple_test.go
@@ -1,0 +1,28 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitsOnBranchSimple(t *testing.T) {
+	repo := setupRepo()
+	createTestHistory(repo)
+
+	head, _ := repo.Head()
+
+	testGit := &Git{repo: repo}
+
+	commits, err := testGit.CommitsOnBranchSimple(head.Hash())
+
+	assert.Equal(t, 4, len(commits))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "third commit on new branch", commits[0].Message)
+	assert.Equal(t, err, nil)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "second commit on new branch\n\n Long message", commits[1].Message)
+	assert.Equal(t, err, nil)
+}

--- a/commits_on_branch_test.go
+++ b/commits_on_branch_test.go
@@ -62,7 +62,7 @@ func createTestHistory(repo *git.Repository) {
 	createCommit(repo, "test commit on master")
 	createBranch(repo)
 	createCommit(repo, "commit on new branch")
-	createCommit(repo, "second commit on new branch")
+	createCommit(repo, "second commit on new branch\n\n Long message")
 	createCommit(repo, "third commit on new branch")
 }
 


### PR DESCRIPTION
Uses the bare refs instead of full objects